### PR TITLE
Patch 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ OnboardIQ.Client = (apiToken, env) => {
 
   this.env = env;
   this.apiToken = apiToken;
-  this.uri = 'https://www.onboardiq.com/api/' + env;
+  this.uri = 'https://api.fountain.com/' + env;
 };
 
 // ────────────────────────────────────────────────────────────────────────────────

--- a/test/mockEndpoints.js
+++ b/test/mockEndpoints.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var nock = require('nock');
-var rootURL = 'https://www.onboardiq.com/api';
+var rootURL = 'https://api.fountain.com';
 
 var mockApplicant = require('./mocks/applicant.json');
 var mockApplicantLabels = require('./mocks/applicantLabels.json');


### PR DESCRIPTION
Fountain is deprecating the www.onboardiq.com apis.  This PR switches the urls so the new api.fountain.com urls are used.